### PR TITLE
Feature: login, register 서비스 로직 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
     "react/jsx-props-no-spreading": "off", //spread사용시 error off
     "jsx-a11y/no-static-element-interactions": "off", // div에 이벤트 등록이 error off
     "jsx-a11y/click-events-have-key-events": "off", //onClick 이벤트에 key event 포함 안하면 error off
+    "import/no-cycle": "off", // 순환 의존성 감지 방지 off
     "@typescript-eslint/naming-convention": [
       "error",
       {

--- a/app/action/login.ts
+++ b/app/action/login.ts
@@ -1,0 +1,24 @@
+'use server';
+
+import { api } from '@/lib/utils';
+import { AuthResponse } from '@/type/user';
+import axios from 'axios';
+import { cookies } from 'next/headers';
+
+const login = async (email: string, password: string): Promise<ActionType<AuthResponse>> => {
+  try {
+    const response = await api.post('/auth/login', { email, password });
+    const { data } = response;
+    const token = data.accessToken;
+
+    cookies().set('GilaToken', token);
+    return { success: true, message: '성공' };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      return { success: false, message: error.response?.data.message };
+    }
+    return { success: false, message: '로그인 실패' };
+  }
+};
+
+export default login;

--- a/app/action/register.ts
+++ b/app/action/register.ts
@@ -1,0 +1,25 @@
+'use server';
+
+import { api } from '@/lib/utils';
+import { User } from '@/type/user';
+import axios from 'axios';
+
+interface Props {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+const register = async ({ email, nickname, password }: Props): Promise<ActionType<User>> => {
+  try {
+    await api.post('/users', { email, nickname, password });
+    return { success: true, message: '성공' };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      return { success: false, message: error.response?.data.message };
+    }
+    return { success: false, message: '회원가입 실패' };
+  }
+};
+
+export default register;

--- a/app/action/token.ts
+++ b/app/action/token.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import { cookies } from 'next/headers';
+
+const getAccessToken = async (): Promise<string | null> => {
+  const cookieStore = cookies();
+  const accessToken = cookieStore.get('GilaToken');
+
+  if (!accessToken) return null;
+
+  return accessToken.value;
+};
+
+export default getAccessToken;

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,60 @@
+import { api } from '@/lib/utils';
+import axios from 'axios';
+import NextAuth, { Session, User } from 'next-auth';
+import { JWT } from 'next-auth/jwt';
+import CredentialsProvider from 'next-auth/providers/credentials';
+
+export const authOption = {
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'email', type: 'email' },
+        password: { label: 'password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials) return null;
+        try {
+          const { email, password } = credentials;
+          const response = await api.post('/auth/login', { email, password });
+          return response?.data;
+        } catch (error) {
+          // 해당 구간에서 에러 메세지를 받아서 다시 에러를 던져줘야 form에서 에러메세지 처리 가능
+          if (axios.isAxiosError(error)) {
+            throw new Error(error.response?.data.message);
+          }
+          throw new Error('로그인 실패');
+        }
+      },
+    }),
+  ],
+
+  secret: process.env.NEXTAUTH_SECRET,
+
+  session: {
+    maxAge: 60 * 60,
+  },
+
+  pages: {
+    signIn: '/login',
+  },
+
+  callbacks: {
+    async jwt({ token, user }: { token: JWT; user: User }) {
+      const copyToken = { ...token };
+      if (user) {
+        copyToken.accessToken = user?.accessToken;
+      }
+      return copyToken;
+    },
+    async session({ session, token }: { session: Session; token: JWT }) {
+      const copySession = { ...session };
+      copySession.accessToken = token.accessToken;
+      return copySession;
+    },
+  },
+};
+
+const handler = NextAuth(authOption);
+
+export { handler as GET, handler as POST };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,27 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import getAccessToken from '@/app/action/token';
+import axios from 'axios';
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
+
+export const api = axios.create({
+  baseURL: 'https://sp-globalnomad-api.vercel.app/5-4',
+});
+
+try {
+  api.interceptors.request.use(
+    async (config) => {
+      const token = await getAccessToken();
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+      return config;
+    },
+    (error) => {
+      return Promise.reject(error);
+    },
+  );
+} catch (error) {}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,8 +1,10 @@
-import getAccessToken from '@/app/action/token';
+import { authOption } from '@/app/api/auth/[...nextauth]/route';
 import axios from 'axios';
 import { type ClassValue, clsx } from 'clsx';
+import { getServerSession } from 'next-auth';
 import { twMerge } from 'tailwind-merge';
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
@@ -14,9 +16,11 @@ export const api = axios.create({
 try {
   api.interceptors.request.use(
     async (config) => {
-      const token = await getAccessToken();
+      // nextauth 서버 세션에 저장된 토큰값 가져오기
+      const token = await getServerSession(authOption);
       if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
+        // eslint-disable-next-line no-param-reassign
+        config.headers.Authorization = `Bearer ${token.accessToken}`;
       }
       return config;
     },
@@ -24,4 +28,6 @@ try {
       return Promise.reject(error);
     },
   );
-} catch (error) {}
+} catch (error) {
+  /* empty */
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,26 +5,20 @@ const FALLBACK_URL = '/mypage';
 // eslint-disable-next-line consistent-return
 const protectiedAuth = async (req: NextRequest, token: boolean) => {
   const url = req.nextUrl.clone();
-  const { pathname } = req.nextUrl;
 
   if (!token) {
-    // 토큰값이 falsy한 사용자가 withAuth페이지에 진입하려하면,
-    // 미들웨어에서 req객체 중에 NextUrl 안에 담긴 pathname을 쿼리스트링을 붙여서 로그인페이지로 리다이렉트 시킴
     url.pathname = '/login';
-    // 로그인하면 이전페이지로 이동하기 위해서 쿼리스트링사용하여 붙여줌.
-    url.search = `callbackUrl=${pathname}`;
 
     return NextResponse.redirect(url);
   }
 };
 
 // eslint-disable-next-line consistent-return
-const publicAuth = async (req: NextRequest, token: boolean, to: string | null) => {
+const publicAuth = async (req: NextRequest, token: boolean) => {
   const url = req.nextUrl.clone();
 
   if (token) {
-    url.pathname = to ?? FALLBACK_URL;
-    url.search = '';
+    url.pathname = FALLBACK_URL;
 
     return NextResponse.redirect(url);
   }
@@ -35,23 +29,14 @@ const publicPageList = ['/login', '/register'];
 
 // eslint-disable-next-line @typescript-eslint/naming-convention, consistent-return
 export default async function middleware(req: NextRequest) {
-  // 미들웨어 쿠키
-  const cookie = req.cookies.get('Authroization')?.value || '';
-
-  // setting Headers
-  const requestHeaders = new Headers(req.headers);
-  requestHeaders.set('Authroization', cookie);
-
   const token = await getToken({ req });
-  const { searchParams } = req.nextUrl;
-  const callbackUrl = searchParams.get('callbackUrl');
   const { pathname } = req.nextUrl;
 
   const isProtectiedRoutes = protectiedPageList.includes(pathname);
   const ispublicRoutes = publicPageList.includes(pathname);
 
   if (isProtectiedRoutes) return protectiedAuth(req, !!token);
-  if (ispublicRoutes) return publicAuth(req, !!token, callbackUrl);
+  if (ispublicRoutes) return publicAuth(req, !!token);
 }
 
 // 미들웨어가 실행될 특정 pathname을 지정하면, 해당 pathname에서만 실행 가능

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const middleware = (request: NextRequest) => {
+  const hasAccessToken = request.cookies.has('GilaToken');
+
+  const { pathname } = request.nextUrl;
+  const authRoutes = ['/login', '/register'];
+
+  const isAuthRoutes = authRoutes.includes(pathname);
+
+  if (hasAccessToken && isAuthRoutes) {
+    return NextResponse.redirect(new URL('/', request.url));
+  }
+
+  return NextResponse.next();
+};
+
+export const config = {
+  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)'],
+};

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,20 +1,60 @@
+import { getToken } from 'next-auth/jwt';
 import { NextRequest, NextResponse } from 'next/server';
 
-export const middleware = (request: NextRequest) => {
-  const hasAccessToken = request.cookies.has('GilaToken');
+const FALLBACK_URL = '/mypage';
+// eslint-disable-next-line consistent-return
+const protectiedAuth = async (req: NextRequest, token: boolean) => {
+  const url = req.nextUrl.clone();
+  const { pathname } = req.nextUrl;
 
-  const { pathname } = request.nextUrl;
-  const authRoutes = ['/login', '/register'];
+  if (!token) {
+    // 토큰값이 falsy한 사용자가 withAuth페이지에 진입하려하면,
+    // 미들웨어에서 req객체 중에 NextUrl 안에 담긴 pathname을 쿼리스트링을 붙여서 로그인페이지로 리다이렉트 시킴
+    url.pathname = '/login';
+    // 로그인하면 이전페이지로 이동하기 위해서 쿼리스트링사용하여 붙여줌.
+    url.search = `callbackUrl=${pathname}`;
 
-  const isAuthRoutes = authRoutes.includes(pathname);
-
-  if (hasAccessToken && isAuthRoutes) {
-    return NextResponse.redirect(new URL('/', request.url));
+    return NextResponse.redirect(url);
   }
-
-  return NextResponse.next();
 };
 
+// eslint-disable-next-line consistent-return
+const publicAuth = async (req: NextRequest, token: boolean, to: string | null) => {
+  const url = req.nextUrl.clone();
+
+  if (token) {
+    url.pathname = to ?? FALLBACK_URL;
+    url.search = '';
+
+    return NextResponse.redirect(url);
+  }
+};
+
+const protectiedPageList = ['/mypage'];
+const publicPageList = ['/login', '/register'];
+
+// eslint-disable-next-line @typescript-eslint/naming-convention, consistent-return
+export default async function middleware(req: NextRequest) {
+  // 미들웨어 쿠키
+  const cookie = req.cookies.get('Authroization')?.value || '';
+
+  // setting Headers
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set('Authroization', cookie);
+
+  const token = await getToken({ req });
+  const { searchParams } = req.nextUrl;
+  const callbackUrl = searchParams.get('callbackUrl');
+  const { pathname } = req.nextUrl;
+
+  const isProtectiedRoutes = protectiedPageList.includes(pathname);
+  const ispublicRoutes = publicPageList.includes(pathname);
+
+  if (isProtectiedRoutes) return protectiedAuth(req, !!token);
+  if (ispublicRoutes) return publicAuth(req, !!token, callbackUrl);
+}
+
+// 미들웨어가 실행될 특정 pathname을 지정하면, 해당 pathname에서만 실행 가능
 export const config = {
-  matcher: ['/((?!.*\\..*|_next).*)', '/', '/(api|trpc)(.*)'],
+  mathcher: [...protectiedPageList, ...publicPageList],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.401.0",
         "next": "14.2.4",
+        "next-auth": "^4.24.7",
         "next-themes": "^0.3.0",
         "react": "^18",
         "react-dom": "^18",
@@ -57,6 +58,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+      "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -421,6 +433,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1346,6 +1366,14 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3399,6 +3427,14 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3718,6 +3754,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.7",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.7.tgz",
+      "integrity": "sha512-iChjE8ov/1K/z98gdKbn2Jw+2vLgJtVV39X+rCP5SGnVQuco7QOr19FRNGMIrD8d3LYhHWV9j9sKLzq1aDWWQQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.5.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "next": "^12.2.5 || ^13 || ^14",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18",
+        "react-dom": "^17.0.2 || ^18"
+      },
+      "peerDependenciesMeta": {
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.3.0.tgz",
@@ -3761,6 +3824,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3913,6 +3981,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3920,6 +3996,39 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.5.tgz",
+      "integrity": "sha512-5P4qO9nGJzB5PI0LFlhj4Dzg3m4odt0qsJTfyEtZyOlkgpILwEioOhVVJOrS1iVH494S4Ee5OCjjg6Bf5WOj3w==",
+      "dependencies": {
+        "jose": "^4.15.5",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/optionator": {
@@ -4218,6 +4327,26 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/preact": {
+      "version": "10.22.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.22.1.tgz",
+      "integrity": "sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4327,6 +4456,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4455,6 +4589,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.2",
@@ -5305,6 +5444,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5499,6 +5646,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "2.4.5",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.401.0",
     "next": "14.2.4",
+    "next-auth": "^4.24.7",
     "next-themes": "^0.3.0",
     "react": "^18",
     "react-dom": "^18",

--- a/type/action.ts
+++ b/type/action.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface ActionType<T> {
+  success: boolean;
+  message: string;
+  data?: T;
+}

--- a/type/next-auth.d.ts
+++ b/type/next-auth.d.ts
@@ -1,0 +1,18 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import NextAuth from 'next-auth';
+
+declare module 'next-auth' {
+  interface Session {
+    accessToken?: string;
+  }
+
+  interface User {
+    accessToken: string;
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    accessToken?: string;
+  }
+}

--- a/type/user.ts
+++ b/type/user.ts
@@ -1,0 +1,14 @@
+export interface User {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AuthResponse {
+  accessToken: string;
+  refreshToken: string;
+  user: User;
+}


### PR DESCRIPTION
지금 서버액션으로 로그인과 회원가입 적용되어 있습니다.
```ts
interface ActionType<T> {
  success: boolean;
  message: string;
  data?: T;
}
```
로그인, 회원가입 액션에 대한 리턴 타입입니다. form에서 사용하실때 success로 성공 여부와 message 텍스트 사용하시면 됩니다.
지금 테스트하면서 shadcn form대충 만들어서 같이 push했는데 참고하시면 될것같습니다.

***

이후에 nextauth로 마이그레이션 진행했습니다.
```ts
  async function onSubmit(values: z.infer<typeof formSchema>) {
    const { email, password } = values;
    // nextauth 메소드인 signIn으로 로그인, 해당 형식으로 작성해주시면 됩니다.
    const result = await signIn('credentials', {
      email,
      password,
      redirect: false, // 로그인했을때 페이지 리다이렉션 제거
    });
    if (result?.ok) {
      router.replace('/');
    } else if (result?.error) {
      // next-auth에서 던져준 에러를 받아서 사용함
      toast.error(result?.error);
    }
  }
```
로그인 폼에서 사용하실때 이렇게 사용하시면 됩니다. 그리고 정상적으로 테스트하시려면 로컬에 `.env.local`파일 생성후
>NEXT_PUBLIC_BASE_URL=http://localhost:3000
NEXTAUTH_URL=http://localhost:3000
NEXTAUTH_SECRET=아무 문자열

해당 값 넣어주시면 됩니다. nextauth secret key의 경우에는 나중에 배포시에 난수 생성해서 넣어줄 예정이라 지금은 아무 문자열 넣으셔도 동작합니다.

