### PR TITLE
Feature: 로그인, 회원가입 기능 form 연동

### DIFF
--- a/app/(auth)/login/_components/login-form.tsx
+++ b/app/(auth)/login/_components/login-form.tsx
@@ -10,12 +10,15 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { toast } from 'sonner';
 import { PASSWORD_REGEX } from '@/constants';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import PasswordInput from '@/components/ui/password-input';
 import { useState } from 'react';
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 
 const LoginFields = [
   {
@@ -48,13 +51,25 @@ export default function LoginForm() {
       password: '',
     },
   });
+  const router = useRouter();
 
   const handleVisibility = () => {
     setIsVisible(!isVisible);
   };
 
-  const onSubmit = (values: z.infer<typeof LoginSchema>) => {
-    return values;
+  const onSubmit = async (values: z.infer<typeof LoginSchema>) => {
+    const { email, password } = values;
+    const result = await signIn('credentials', {
+      email,
+      password,
+      redirect: false, // 로그인했을때 페이지 리다이렉션 제거
+    });
+    if (result?.ok) {
+      router.replace('/');
+    } else if (result?.error) {
+      // next-auth에서 던져준 에러를 받아서 사용함
+      toast.error(result?.error);
+    }
   }; // 팀 컨벤션은 handle이지만 라이브러리 코드와 구분을 위해 on으로 만들었습니다.
 
   return (

--- a/app/(auth)/register/_components/register-form.tsx
+++ b/app/(auth)/register/_components/register-form.tsx
@@ -16,6 +16,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import PasswordInput from '@/components/ui/password-input';
 import { useState } from 'react';
+import register from '@/app/action/register';
+import { toast } from 'sonner';
+import { useRouter } from 'next/navigation';
 
 const RegisterFields = [
   {
@@ -80,13 +83,21 @@ export default function RegisterForm() {
       confirm: '',
     },
   });
+  const router = useRouter();
 
   const handleVisibility = () => {
     setIsVisible(!isVisible);
   };
 
-  const onSubmit = (values: z.infer<typeof RegisterSchema>) => {
-    return values;
+  const onSubmit = async (values: z.infer<typeof RegisterSchema>) => {
+    const { nickname, email, password } = values;
+    const action = await register({ email, nickname, password });
+    if (!action.success) {
+      toast.error(action.message);
+      return;
+    }
+    router.replace('/login');
+    toast.success(action.message);
   }; // 팀 컨벤션은 handle이지만 라이브러리 코드와 구분을 위해 on으로 만들었습니다.
 
   return (

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -17,7 +17,7 @@ export const authOption = {
         try {
           const { email, password } = credentials;
           const response = await api.post('/auth/login', { email, password });
-          return response?.data;
+          return response.data;
         } catch (error) {
           // 해당 구간에서 에러 메세지를 받아서 다시 에러를 던져줘야 form에서 에러메세지 처리 가능
           if (axios.isAxiosError(error)) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import { Toaster } from '@/components/ui/sonner';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -16,7 +17,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <Toaster />
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
로그인, 회원가입 기능 폼이랑 연결했습니다.
미들웨어 잘 동작하고 토스트도 일단 추가해뒀습니다.
아까 팀미팅때 문제였던 페이지 이동문제도 확인해보니 일단 잘 되어서
```ts
  const onSubmit = async (values: z.infer<typeof LoginSchema>) => {
    const { email, password } = values;
    const result = await signIn('credentials', {
      email,
      password,
      redirect: false, // 로그인했을때 페이지 리다이렉션 제거
    });
    if (result?.ok) {
      router.replace('/');
    } else if (result?.error) {
      // next-auth에서 던져준 에러를 받아서 사용함
      toast.error(result?.error);
    }
  }; // 팀 컨벤션은 handle이지만 라이브러리 코드와 구분을 위해 on으로 만들었습니다.
```
replace로 적용시켜놨습니다. 추후에 문제발생하면 바꿔보겠습니다.